### PR TITLE
bugfix 26, 27: update PHARMCAT_VCFPREPROCESSOR 

### DIFF
--- a/modules/nf-core/pharmcat/vcfpreprocessor/main.nf
+++ b/modules/nf-core/pharmcat/vcfpreprocessor/main.nf
@@ -10,7 +10,9 @@ process PHARMCAT_VCFPREPROCESSOR {
     input:
     tuple val(meta), path(vcf_gz), path(vcf_index)
     tuple val(meta2), path(fasta)
-    tuple val(meta3), path(fai)
+    // Stage fasta indices (.fai and .gzi for bgzipped fasta) so htslib finds them
+    // next to the fasta and does not regenerate them in the source directory.
+    tuple val(meta3), path(fasta_indices)
     tuple val(meta4), path(pharmcat_positions), path(pharmcat_positions_index)
     tuple val(meta5), path(pharmcat_uniallelic_positions), path(pharmcat_uniallelic_positions_index)
 

--- a/subworkflows/local/pharmcat_vcf_processing.nf
+++ b/subworkflows/local/pharmcat_vcf_processing.nf
@@ -7,7 +7,7 @@ workflow PHARMCAT_VCF_PROCESSING {
     take:
     ch_vcf                      // channel: [ val(meta), [ vcf ], [ tbi ] ]
     ch_ref_fasta                // channel: [ val(meta), path(fasta) ]
-    ch_ref_fasta_index          // channel: [ val(meta), path(fasta_index) ]
+    ch_ref_fasta_indices        // channel: [ val(meta), [ path(fai), path(gzi) ] ]
     ch_pc_pos                   // channel: [ val(meta), path(pharmcat_positions_vcf), path(pharmcat_positions_vcf_index) ]
     ch_pc_uniallelic_pos        // channel: [ val(meta), path(pharmcat_uniallelic_pos_vcf), path(pharmcat_uniallelic_pos_vcf_index) ]
     ch_target_pass_bed          // channel: [ val(meta), path(target_pass_bed) ]
@@ -16,26 +16,33 @@ workflow PHARMCAT_VCF_PROCESSING {
 
     // VCF Preprocessing
     PHARMCAT_VCFPREPROCESSOR(
-        ch_vcf, 
-        ch_ref_fasta, 
-        ch_ref_fasta_index, 
-        ch_pc_pos.first(), 
+        ch_vcf,
+        ch_ref_fasta,
+        ch_ref_fasta_indices,
+        ch_pc_pos.first(),
         ch_pc_uniallelic_pos.first()
-        ).set { ch_preprocessed_vcf } 
+        ).set { ch_preprocessed_vcf }
 
     // VCF indexing
     TABIX_TABIX(ch_preprocessed_vcf.preprocessed_vcf).set { ch_preprocessed_vcf_tbi }
 
-    // Filter VCF to only include sites with depth > input min_dp
-    BCFTOOLS_VIEW ( 
-            ch_preprocessed_vcf.preprocessed_vcf.join(
-                ch_preprocessed_vcf_tbi.index,
-                failOnMismatch:true, 
-                failOnDuplicate:true
-            ),
-            ch_target_pass_bed.map { meta, pass_bed_path -> [ pass_bed_path ] },
+    // Filter VCF to only include sites with depth > input min_dp.
+    // Join VCF, index and target-pass BED on meta so each sample's BED stays paired
+    // with its own VCF; then split into the two channels BCFTOOLS_VIEW expects.
+    ch_preprocessed_vcf.preprocessed_vcf
+        .join(ch_preprocessed_vcf_tbi.index, failOnMismatch: true, failOnDuplicate: true)
+        .join(ch_target_pass_bed,            failOnMismatch: true, failOnDuplicate: true)
+        .multiMap { meta, vcf, tbi, pass_bed ->
+            vcf_tbi:  [ meta, vcf, tbi ]
+            pass_bed: pass_bed
+        }
+        .set { ch_view_input }
+
+    BCFTOOLS_VIEW (
+            ch_view_input.vcf_tbi,
+            ch_view_input.pass_bed,
             [],
-            [] 
+            []
         ).set { ch_preprocessed_vcf_pass }
 
     emit:

--- a/workflows/precisionpgx.nf
+++ b/workflows/precisionpgx.nf
@@ -146,10 +146,12 @@ workflow PRECISIONPGX {
 
     ch_pc_reference_fasta           = params.pharmcat_reference_fasta           ? Channel.fromPath(params.pharmcat_reference_fasta).map {it -> [[id:it.simpleName], it]}.collect()
                                                                                 : Channel.value([[:],[]])
-    ch_pc_reference_fasta_index     = params.pharmcat_reference_fasta_index     ? Channel.fromPath(params.pharmcat_reference_fasta_index).map {it -> [[id:it.simpleName], it]}.collect()
-                                                                                : Channel.value([[:],[]])
-    ch_pc_reference_fasta_fai       = params.pharmcat_reference_fasta_fai       ? Channel.fromPath(params.pharmcat_reference_fasta_fai).map {it -> [[id:it.simpleName], it]}.collect()
-                                                                                : Channel.value([[:],[]])
+    // Stage .fai and .gzi together so the VCF preprocessor finds both next to the
+    // bgzipped fasta and does not regenerate them (causes races under parallelism, #26).
+    ch_pc_reference_fasta_indices   = (params.pharmcat_reference_fasta_fai && params.pharmcat_reference_fasta_index)
+                                        ? Channel.fromPath([params.pharmcat_reference_fasta_fai, params.pharmcat_reference_fasta_index]).collect()
+                                            .map { files -> [[id: 'pharmcat_reference'], files] }
+                                        : Channel.value([[:],[]])
 
 
     //
@@ -329,9 +331,9 @@ workflow PRECISIONPGX {
     ).set { ch_pharmcat_input_joined }
 
     PHARMCAT_VCF_PROCESSING(
-        ch_pharmcat_input_joined, 
-        ch_pc_reference_fasta, 
-        ch_pc_reference_fasta_fai, 
+        ch_pharmcat_input_joined,
+        ch_pc_reference_fasta,
+        ch_pc_reference_fasta_indices,
         ch_pc_positions_vcf.join(
             ch_pc_positions_vcf_index, 
             failOnMismatch:true, 


### PR DESCRIPTION
Here are proposed fixes for 26, 27.


#26 — PharmCAT regenerates the fasta index on every run
Symptom: Under parallel batches, PharmCAT's preprocessor races to rewrite reference.fna.bgz.fai (next to the source file), and some tasks read a half-written index → Failed to read FASTA index.

Root cause: The pipeline accepts three reference-related params: the bgzipped fasta, its .gzi (bgzip random-access index), and its .fai (sequence index). In [workflows/precisionpgx.nf:147-154](vscode-webview://1ries7agkgvpdq13ne3jpr4ke46cq1aeb1d1s0289nf560spl6ji/workflows/precisionpgx.nf#L147-L154), all three channels are built, but only the .fasta and .fai channels are passed into [PHARMCAT_VCF_PROCESSING](vscode-webview://1ries7agkgvpdq13ne3jpr4ke46cq1aeb1d1s0289nf560spl6ji/subworkflows/local/pharmcat_vcf_processing.nf). The .gzi channel was constructed and dropped.

Nextflow only stages files that are declared in a process's input: block. So the task workdir for [PHARMCAT_VCFPREPROCESSOR](vscode-webview://1ries7agkgvpdq13ne3jpr4ke46cq1aeb1d1s0289nf560spl6ji/modules/nf-core/pharmcat/vcfpreprocessor/main.nf) had reference.fna.bgz (symlink) and reference.fna.bgz.fai (symlink) but no .gzi. When PharmCAT opens the bgzipped fasta, htslib needs the .gzi to seek, doesn't find it, and rebuilds it. Since the fasta is a symlink, htslib writes the regenerated .gzi (and re-touches .fai) next to the source file — i.e. into the shared reference directory, where every parallel task is racing.

Fix:

In [precisionpgx.nf](vscode-webview://1ries7agkgvpdq13ne3jpr4ke46cq1aeb1d1s0289nf560spl6ji/workflows/precisionpgx.nf), collapse the orphaned .gzi channel and the .fai channel into a single ch_pc_reference_fasta_indices that carries both files as one tuple [meta, [fai, gzi]].
In the module, widen the third input from tuple val(meta3), path(fai) to tuple val(meta3), path(fasta_indices) — passing a list to path() stages every file in the list under its original filename. Both indices now land in the task workdir alongside the fasta.
Plumb the new channel through the subworkflow.
htslib now finds both indices in-place and doesn't regenerate.

#27 — BCFTOOLS_VIEW filters with the wrong sample's BED
Symptom: For some samples, the bcftools view --regions-file …bed command uses another sample's target.pass.bed. The issue reporter saw NA19109.deepvariant.pharmcat.preprocessed.vcf.bgz being filtered against NA12878.target.pass.bed.

Root cause: In [pharmcat_vcf_processing.nf](vscode-webview://1ries7agkgvpdq13ne3jpr4ke46cq1aeb1d1s0289nf560spl6ji/subworkflows/local/pharmcat_vcf_processing.nf), the original call looked like this:


BCFTOOLS_VIEW (
    ch_preprocessed_vcf.preprocessed_vcf.join(ch_preprocessed_vcf_tbi.index, ...), // [meta, vcf, tbi]
    ch_target_pass_bed.map { meta, pass_bed_path -> [ pass_bed_path ] },           // meta stripped
    [], []
)
The first argument is correctly keyed by meta (VCF and index joined per sample). The second argument was deliberately stripped of its meta to match BCFTOOLS_VIEW's signature (path regions — not a tuple). That stripping is the bug.

When two queue channels feed a Nextflow process and there is no shared key to join on, Nextflow pairs them by emission order: the n-th emission on the first channel goes with the n-th emission on the second. Here:

The VCF+index channel emits per sample in the order PHARMCAT_VCFPREPROCESSOR tasks complete.
The BED channel emits per sample in the order the upstream TARGET_PASS_REGIONS tasks complete.
Both are async. Under real parallelism the two orderings drift apart → sample A's VCF gets paired with sample B's BED. The channel-only repro I ran demonstrated this deterministically (sampleA → B.bed, sampleB → A.bed).

Fix: keep the BED keyed and .join it onto the VCF+index tuple, then split the merged stream back into two channels with multiMap:


ch_preprocessed_vcf.preprocessed_vcf
    .join(ch_preprocessed_vcf_tbi.index, failOnMismatch: true, failOnDuplicate: true)
    .join(ch_target_pass_bed,            failOnMismatch: true, failOnDuplicate: true)
    .multiMap { meta, vcf, tbi, pass_bed ->
        vcf_tbi:  [ meta, vcf, tbi ]
        pass_bed: pass_bed
    }
    .set { ch_view_input }

BCFTOOLS_VIEW(ch_view_input.vcf_tbi, ch_view_input.pass_bed, [], [])
Two things make this correct:

.join on meta guarantees per-sample pairing, regardless of completion order.
multiMap splits one source channel into two sub-channels emitted in lockstep, so the BED Nextflow stages into each BCFTOOLS_VIEW task always belongs to the same sample as that task's VCF.
The failOnMismatch/failOnDuplicate flags also turn any future drift into a loud error rather than silent mispairing.