### PR TITLE
docs(usage): list case_id and lane as required samplesheet columns

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -323,11 +323,15 @@ Each label has a defined resource usage in `conf/base.config`
 
 The columns that are accepted in the samplesheet are defined in the file `assets/schema_input.json`. 
 
-Required columns are: 
+Required columns are:
 
-`sample`: sample name 
+`sample`: sample name
+
+`case_id`: case identifier (samples sharing a `case_id` are processed together)
 
 `type`: T (tumour) or N (normal)
+
+`lane`: lane identifier (an integer, or a string with no whitespace)
 
 `seq_type`: dna or rna. (required by nf-core modules for hla genotyping with optitype)
 


### PR DESCRIPTION
Proposed fix for bug 10. Done with the help of claude code

## Summary

- `docs/usage.md` prose listed `sample`, `type`, `seq_type` as required columns, but `assets/schema_input.json` declares `sample`, `case_id`, `type`, `lane`, `seq_type` as required.
- Added `case_id` and `lane` to the prose so the doc matches the schema and the example CSV directly below it (which already had both columns as of 432dc19).

Closes #10