### PR TITLE
Fix pharmcat pairing and staging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ testing*
 *.pyc
 null/
 *backup
+test_data/

--- a/conf/modules/pharmcat_vcf_processing.config
+++ b/conf/modules/pharmcat_vcf_processing.config
@@ -28,6 +28,11 @@ process {
     withName: '.*PHARMCAT_VCF_PROCESSING:PHARMCAT_VCFPREPROCESSOR' {
         ext.args = {" --missing-to-ref "} //Assume all non-called sites are reference
         ext.prefix = { "${meta.id}.${params.variant_caller}.pharmcat" }
+        // Copy (don't symlink) inputs into the workdir so that when htslib
+        // touches/rewrites reference.fna.bgz.fai it touches the per-task
+        // copy, not the shared source file. Without this, parallel tasks
+        // race on the source-side .fai (issue #26).
+        stageInMode = 'copy'
     }
 
     withName: '.*PHARMCAT_VCF_PROCESSING:BCFTOOLS_VIEW' {

--- a/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
+++ b/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
@@ -59,7 +59,11 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
 
         // Get stats for each demultiplexed read pair.
         bam_sorted_indexed = ch_align.join(SAMTOOLS_INDEX_ALIGN.out.index, failOnMismatch:true, failOnDuplicate:true)
-        SAMTOOLS_STATS ( bam_sorted_indexed, [[],[]] )
+        SAMTOOLS_STATS (
+            bam_sorted_indexed,
+            ch_genome_fasta.combine(ch_genome_fai.map { _meta, fai -> fai })
+                           .map { meta, fasta, fai -> [meta, fasta, fai] }
+        )
 
         // Merge multiple lane samples and index
         ch_align

--- a/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
+++ b/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
@@ -75,8 +75,14 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
                 }
             .set{ bams }
 
-        // If there are no samples to merge, skip the process
-        SAMTOOLS_MERGE ( bams.multiple, ch_genome_fasta, ch_genome_fai, [])
+        // If there are no samples to merge, skip the process.
+        // The nf-core SAMTOOLS_MERGE module bundles (bams, indices) into one
+        // tuple and (fasta, fai, gzi) into another, so build matching shapes.
+        SAMTOOLS_MERGE (
+            bams.multiple.map { meta, bam_list -> [meta, bam_list, []] },
+            ch_genome_fasta.combine(ch_genome_fai.map { _meta, fai -> fai })
+                           .map { meta, fasta, fai -> [meta, fasta, fai, []] }
+        )
         prepared_bam = bams.single.mix(SAMTOOLS_MERGE.out.bam)
 
         // GET ALIGNMENT FROM SELECTED CONTIGS

--- a/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
+++ b/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
@@ -58,7 +58,7 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
         SAMTOOLS_INDEX_ALIGN ( ch_align )
 
         // Get stats for each demultiplexed read pair.
-        bam_sorted_indexed = ch_align.join(SAMTOOLS_INDEX_ALIGN.out.bai, failOnMismatch:true, failOnDuplicate:true)
+        bam_sorted_indexed = ch_align.join(SAMTOOLS_INDEX_ALIGN.out.index, failOnMismatch:true, failOnDuplicate:true)
         SAMTOOLS_STATS ( bam_sorted_indexed, [[],[]] )
 
         // Merge multiple lane samples and index
@@ -82,7 +82,7 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
         // GET ALIGNMENT FROM SELECTED CONTIGS
         if (params.extract_alignments) {
             SAMTOOLS_INDEX_EXTRACT ( prepared_bam )
-            extract_bam_sorted_indexed = prepared_bam.join(SAMTOOLS_INDEX_EXTRACT.out.bai, failOnMismatch:true, failOnDuplicate:true)
+            extract_bam_sorted_indexed = prepared_bam.join(SAMTOOLS_INDEX_EXTRACT.out.index, failOnMismatch:true, failOnDuplicate:true)
             EXTRACT_ALIGNMENTS( extract_bam_sorted_indexed, ch_genome_fasta, [])
             prepared_bam = EXTRACT_ALIGNMENTS.out.bam
         }
@@ -94,5 +94,5 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
         stats       = SAMTOOLS_STATS.out.stats       // channel: [ val(meta), path(stats) ]
         metrics     = MARKDUPLICATES.out.metrics     // channel: [ val(meta), path(metrics) ]
         marked_bam  = MARKDUPLICATES.out.bam         // channel: [ val(meta), path(bam) ]
-        marked_bai  = SAMTOOLS_INDEX_MARKDUP.out.bai // channel: [ val(meta), path(bai) ]
+        marked_bai  = SAMTOOLS_INDEX_MARKDUP.out.index // channel: [ val(meta), path(bai) ]
 }

--- a/subworkflows/local/align_sentieon/main.nf
+++ b/subworkflows/local/align_sentieon/main.nf
@@ -42,7 +42,7 @@ workflow ALIGN_SENTIEON {
             EXTRACT_ALIGNMENTS( ch_bam_bai, ch_genome_fasta, [])
             ch_bam_bai = EXTRACT_ALIGNMENTS.out.bam
             SAMTOOLS_INDEX_EXTRACT ( EXTRACT_ALIGNMENTS.out.bam )
-            ch_bam_bai = EXTRACT_ALIGNMENTS.out.bam.join(SAMTOOLS_INDEX_EXTRACT.out.bai, failOnMismatch:true, failOnDuplicate:true)
+            ch_bam_bai = EXTRACT_ALIGNMENTS.out.bam.join(SAMTOOLS_INDEX_EXTRACT.out.index, failOnMismatch:true, failOnDuplicate:true)
 
         }
 

--- a/subworkflows/local/pharmcat_vcf_processing.nf
+++ b/subworkflows/local/pharmcat_vcf_processing.nf
@@ -26,16 +26,32 @@ workflow PHARMCAT_VCF_PROCESSING {
     // VCF indexing
     TABIX_TABIX(ch_preprocessed_vcf.preprocessed_vcf).set { ch_preprocessed_vcf_tbi }
 
-    // Filter VCF to only include sites with depth > input min_dp
-    BCFTOOLS_VIEW ( 
-            ch_preprocessed_vcf.preprocessed_vcf.join(
-                ch_preprocessed_vcf_tbi.index,
-                failOnMismatch:true, 
-                failOnDuplicate:true
-            ),
-            ch_target_pass_bed.map { meta, pass_bed_path -> [ pass_bed_path ] },
+    // Filter VCF to only include sites with depth > input min_dp.
+    //
+    // The VCF+tbi tuple and the per-sample target-pass BED come from
+    // different upstream subworkflows (PHARMCAT_VCFPREPROCESSOR vs QC_BAM)
+    // and carry meta dicts that share `id` but differ in other fields. A
+    // `.join` on the full meta therefore fails to match (issue #27). Join on
+    // `meta.id` only, then `multiMap` back into the two channels BCFTOOLS_VIEW
+    // expects (VCF tuple + plain BED path).
+    ch_preprocessed_vcf.preprocessed_vcf
+        .join(ch_preprocessed_vcf_tbi.index, failOnMismatch: true, failOnDuplicate: true)
+        .map { meta, vcf, tbi -> [meta.id, meta, vcf, tbi] }
+        .join(
+            ch_target_pass_bed.map { meta, bed -> [meta.id, bed] },
+            failOnMismatch: true, failOnDuplicate: true
+        )
+        .multiMap { _id, meta, vcf, tbi, bed ->
+            vcf_tbi:  [meta, vcf, tbi]
+            pass_bed: bed
+        }
+        .set { ch_view_input }
+
+    BCFTOOLS_VIEW (
+            ch_view_input.vcf_tbi,
+            ch_view_input.pass_bed,
             [],
-            [] 
+            []
         ).set { ch_preprocessed_vcf_pass }
 
     emit:

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,44 @@
+# Tests
+
+## Validation data
+
+`download_validation_data.sh` downloads PGx-region BAM slices of 4 GeT-RM
+PharmCAT reference samples from the 1000 Genomes 30X high-coverage release.
+
+| Sample   | Population | Notes                                  |
+| -------- | ---------- | -------------------------------------- |
+| NA07000  | CEU        | GeT-RM panel                           |
+| NA12878  | CEU        | GIAB + GeT-RM (most-validated sample)  |
+| NA18526  | CHB        | GeT-RM panel                           |
+| NA19238  | YRI        | GeT-RM panel                           |
+
+Four parallel samples is the minimum needed to reliably trigger the
+`.fai`-rewrite race (issue #26) and the BED-vs-VCF channel mispairing under
+non-deterministic completion order (issue #27).
+
+### Usage
+
+```bash
+pixi exec --spec 'samtools>=1.18' -- bash tests/download_validation_data.sh
+```
+
+The script slices each sample's CRAM against
+`assets/panpgx.TE-97619858.grch38.refseq_mane.whole_genes_snps.annot.v2.bed`
+using a remote CRAM reference (EBI's MD5 service) so no local hg38 fasta is
+required for the slice step. Output lands in `test_data/` (gitignored):
+
+```
+test_data/
+  1000G_2504_high_coverage.sequence.index
+  bams/<SAMPLE>.pgx.bam(.bai)
+  samplesheet.csv
+```
+
+`samplesheet.csv` is pipeline-ready (`schema_input.json` contract).
+
+### Validating against GeT-RM consensus
+
+The published GeT-RM consensus diplotypes (Pratt et al., PharmGKB) are
+*not* downloaded by this script. After running the pipeline on these
+samples, compare PharmCAT's `.report.tsv` calls per gene against the
+published consensus for that sample.

--- a/tests/download_validation_data.sh
+++ b/tests/download_validation_data.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+#
+# Download PGx-region reads of 4 GeT-RM samples from the 1000 Genomes
+# Project 30X high-coverage release (NYGC) and convert them to paired
+# FASTQ — the pipeline's natural input. Used to validate the pipeline and
+# to reproduce issues #26 and #27 (which only manifest with >=2 parallel
+# samples).
+#
+# Strategy: slicing 45 PGx-gene regions in a single samtools call against
+# the remote CRAM is dominated by EBI rate-limiting and CRAM-container
+# reseek overhead; per-region slices in parallel are orders of magnitude
+# faster. Each region completes in ~10-25 s on its own.
+#
+# Output (gitignored): test_data/
+#   fastqs/<SAMPLE>_R1.fq.gz, <SAMPLE>_R2.fq.gz
+#   pgx_genes.bed                # derived from the project's panel BED
+#   samplesheet.csv              # ready to feed to --input
+#   1000G_2504_high_coverage.sequence.index
+#
+# Requirements: bash, curl, awk, samtools >= 1.18. Run via
+#   pixi exec --spec 'samtools>=1.18' -- bash tests/download_validation_data.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DATA_DIR="${REPO_ROOT}/test_data"
+FASTQ_DIR="${DATA_DIR}/fastqs"
+TMP_BAM_DIR="${DATA_DIR}/.tmp_bams"     # per-region BAMs (deleted after merge)
+PANEL_BED="${REPO_ROOT}/assets/panpgx.TE-97619858.grch38.refseq_mane.whole_genes_snps.annot.v2.bed"
+SLICE_BED="${DATA_DIR}/pgx_genes.bed"
+SAMPLESHEET="${DATA_DIR}/samplesheet.csv"
+
+INDEX_URL='http://ftp.1000genomes.ebi.ac.uk/vol1/ftp/data_collections/1000G_2504_high_coverage/1000G_2504_high_coverage.sequence.index'
+INDEX_FILE="${DATA_DIR}/1000G_2504_high_coverage.sequence.index"
+
+# GeT-RM PGx reference samples that also live in the 1KG 30X 2504 release.
+# Spread: CEU, CEU/GIAB, CHB, YRI — enough parallelism to expose #26 and #27.
+SAMPLES=(NA07000 NA12878 NA18526 NA19238)
+
+# How many regions to slice concurrently per sample. Higher values get
+# throttled by EBI after a short burst; 4 stays inside their per-IP cap.
+REGION_CONCURRENCY=4
+
+mkdir -p "${FASTQ_DIR}" "${TMP_BAM_DIR}"
+
+# CRAM reference lazily fetched from EBI's MD5 service; avoids needing a local
+# hg38 fasta for sub-region decoding.
+export REF_PATH='https://www.ebi.ac.uk/ena/cram/md5/%s'
+
+if [[ ! -s "${INDEX_FILE}" ]]; then
+  echo "Fetching 1KG 30X sequence index..."
+  curl -fsSL "${INDEX_URL}" -o "${INDEX_FILE}"
+fi
+
+# Derive a gene-level slicing BED from the panel BED — group exon entries by
+# gene name prefix, take min start / max end per gene, pad 10 kb on each side.
+# ~45 regions, sized to cover star-allele defining variants plus regulatory
+# flanks and (for chr22) the CYP2D6/CYP2D7 hybrid spacer.
+if [[ ! -s "${SLICE_BED}" || "${PANEL_BED}" -nt "${SLICE_BED}" ]]; then
+  awk 'BEGIN { OFS = "\t" }
+    {
+      split($4, a, "_"); g = a[1]
+      if (!(g in chrom)) { chrom[g]=$1; start[g]=$2; end[g]=$3 }
+      if ($2 < start[g]) start[g] = $2
+      if ($3 > end[g])   end[g]   = $3
+    }
+    END {
+      pad = 10000
+      for (g in chrom) {
+        s = start[g] - pad; if (s < 0) s = 0
+        print chrom[g], s, end[g] + pad, g
+      }
+    }' "${PANEL_BED}" | sort -k1,1 -k2,2n > "${SLICE_BED}"
+  echo "Built gene-level slice BED: $(wc -l < "${SLICE_BED}") regions"
+fi
+
+# Build header for the pipeline's samplesheet (schema_input.json contract).
+printf 'sample,case_id,type,lane,fastq_1,fastq_2,seq_type,genes\n' > "${SAMPLESHEET}"
+
+for sample in "${SAMPLES[@]}"; do
+  r1="${FASTQ_DIR}/${sample}_R1.fq.gz"
+  r2="${FASTQ_DIR}/${sample}_R2.fq.gz"
+
+  if [[ -s "${r1}" && -s "${r2}" ]]; then
+    echo "[${sample}] FASTQ already present, skipping."
+  else
+    # Resolve the CRAM URL for this sample.
+    cram_url=$(awk -F'\t' -v s="${sample}" '
+      /^##/        { next }
+      /^#/         { for (i=1;i<=NF;i++) col[$i]=i; next }
+      $col["SAMPLE_NAME"]==s && $col["#ENA_FILE_PATH"] ~ /\.final\.cram$/ {
+        print $col["#ENA_FILE_PATH"]; exit
+      }' "${INDEX_FILE}")
+
+    if [[ -z "${cram_url}" ]]; then
+      echo "[${sample}] no .final.cram entry found in index — skipping." >&2
+      continue
+    fi
+    cram_url="${cram_url/ftp:\/\//https://}"
+
+    echo "[${sample}] slicing ${cram_url}"
+    echo "[${sample}]   $(wc -l < "${SLICE_BED}") regions, ${REGION_CONCURRENCY} concurrent"
+
+    # Per-region parallel slicing. xargs runs samtools view once per BED line,
+    # `--fetch-pairs` brings in mates whose primary read falls outside the
+    # region so paired-end reconstruction stays correct.
+    sample_tmp="${TMP_BAM_DIR}/${sample}"
+    mkdir -p "${sample_tmp}"
+
+    # Resume + retry: slice missing regions, validate with `samtools quickcheck`,
+    # delete corrupted BAMs, and re-slice. Loop a few times so transient EBI
+    # blips don't kill the whole sample.
+    for pass in 1 2 3; do
+      # Drop any BAM that's truncated (e.g. samtools view killed mid-write
+      # in an earlier session) BEFORE deciding what's missing — the
+      # `[[ -s "$out" ]]` test below would accept a nonzero-size but
+      # truncated file otherwise. quickcheck exits non-zero on failure;
+      # swallow it explicitly so `set -e` does not abort here.
+      bad=$(find "${sample_tmp}" -name 'region_*.bam' -print0 2>/dev/null \
+              | { xargs -0 -r samtools quickcheck 2>&1 || true; } \
+              | awk '/was missing EOF block|is not a sequence file/ {print $1}')
+      [[ -n "${bad}" ]] && { echo "${bad}" | xargs -r rm -f; }
+
+      missing=$(
+        awk '{ printf "%s\t%s:%s-%s\n", NR, $1, $2+1, $3 }' "${SLICE_BED}" \
+          | while IFS=$'\t' read -r i region; do
+              out="${sample_tmp}/region_$(printf "%03d" "${i}").bam"
+              [[ -s "${out}" ]] || printf "%s\t%s\n" "${i}" "${region}"
+            done
+      )
+      [[ -z "${missing}" ]] && break
+
+      n=$(printf '%s\n' "${missing}" | wc -l)
+      echo "[${sample}]   pass ${pass}: slicing ${n} region(s), ${REGION_CONCURRENCY} concurrent"
+
+      printf '%s\n' "${missing}" \
+        | xargs -n2 -P "${REGION_CONCURRENCY}" \
+            bash -c '
+              i="$1"; region="$2"
+              out="'"${sample_tmp}"'/region_$(printf "%03d" "$i").bam"
+              samtools view --threads 1 -h -b --fetch-pairs \
+                "'"${cram_url}"'" "$region" -o "$out" 2>/dev/null
+            ' _ || true
+
+      # Drop any BAM that failed quickcheck so the next pass re-slices it.
+      # quickcheck exits non-zero on any failure; swallow it explicitly so
+      # `set -e` does not abort the script here — that is exactly what we
+      # want to inspect.
+      bad=$(find "${sample_tmp}" -name 'region_*.bam' -print0 \
+              | { xargs -0 -r samtools quickcheck 2>&1 || true; } \
+              | awk '/was missing EOF block|is not a sequence file/ {print $1}')
+      [[ -n "${bad}" ]] && { echo "${bad}" | xargs -r rm -f; }
+    done
+
+    # Merge per-region BAMs (drops duplicates from overlapping regions /
+    # mate-fetching automatically when names collide).
+    echo "[${sample}]   merging $(ls "${sample_tmp}"/*.bam | wc -l) region BAMs"
+    samtools merge --threads 2 -f -c -p -o "${sample_tmp}/merged.bam" "${sample_tmp}"/region_*.bam
+
+    # Coordinate-sorted CRAM -> name-collated -> paired FASTQ.
+    echo "[${sample}]   collate + fastq"
+    samtools collate -O -u --threads 2 "${sample_tmp}/merged.bam" \
+      | samtools fastq --threads 2 -1 "${r1}" -2 "${r2}" -s /dev/null -0 /dev/null -
+
+    rm -rf "${sample_tmp}"
+    echo "[${sample}]   R1=$(du -h "${r1}" | cut -f1) R2=$(du -h "${r2}" | cut -f1)"
+  fi
+
+  # Each sample is its own case; lane = 1 (single-lane after merge).
+  printf '%s,%s,N,1,test_data/fastqs/%s,test_data/fastqs/%s,dna,\n' \
+    "${sample}" "${sample}" "$(basename "${r1}")" "$(basename "${r2}")" \
+    >> "${SAMPLESHEET}"
+done
+
+rmdir "${TMP_BAM_DIR}" 2>/dev/null || true
+
+echo
+echo "Done. Sample sheet: ${SAMPLESHEET}"
+cat "${SAMPLESHEET}"

--- a/tests/mwe/.gitignore
+++ b/tests/mwe/.gitignore
@@ -1,0 +1,2 @@
+.mwe-work/
+inputs/

--- a/tests/mwe/README.md
+++ b/tests/mwe/README.md
@@ -1,0 +1,76 @@
+# MWE harnesses for issues #26 and #27
+
+Two tiny Nextflow scripts and a runner that demonstrate the bugs *and*
+the fixes side-by-side. Used to verify the changes on the
+`fix-pharmcat-pairing-and-staging` branch.
+
+## What the bugs are
+
+### #26 — PharmCAT re-indexes the reference genome every time
+
+The pipeline passes `reference.fna.bgz` and its `.fai` into
+`PHARMCAT_VCFPREPROCESSOR`. With Nextflow's default `symlink` staging,
+the workdir's `reference.fna.bgz.fai` is a *symlink to the shared source*.
+htslib, on opening the bgzipped fasta, decides the `.fai` is stale (or
+just touches it on close) and writes — and that write reaches the
+*source* file through the symlink. Under any parallel run, multiple
+tasks race on the source-side `.fai`, producing the `Could not
+understand FASTA index` errors reported in the issue.
+
+**Fix:** [`stageInMode = 'copy'`](../../conf/modules/pharmcat_vcf_processing.config) on
+`PHARMCAT_VCFPREPROCESSOR`. Inputs are copied into each task's workdir,
+so htslib's write hits a private copy. The shared source is untouched
+regardless of how many tasks run in parallel.
+
+### #27 — BCFTOOLS_VIEW filters with the wrong sample's BED
+
+The VCF stream and the target-pass BED stream feeding BCFTOOLS_VIEW
+come from different upstream subworkflows (PHARMCAT_VCFPREPROCESSOR
+and QC_BAM). Their meta dicts share `id` but diverge in other fields
+(e.g. `data_type`). The original code stripped meta from the BED
+channel — `.map { meta, bed -> [bed] }` — so Nextflow paired the two
+channels by emission order. Under genuinely parallel execution the
+orderings diverge and the wrong BED reaches the wrong sample, silently.
+
+A naive switch to `.join(other, ...)` doesn't help either: comparing on
+the full meta map fails to match because of the same field drift.
+
+**Fix:** [`join` on `meta.id` only, then `multiMap` back to the two channels BCFTOOLS_VIEW
+expects](../../subworkflows/local/pharmcat_vcf_processing.nf). Standard nf-core pattern,
+works regardless of other meta-field drift.
+
+## Running the demo
+
+```bash
+bash tests/mwe/run_demo.sh
+```
+
+The script:
+
+1. Runs both MWEs with the current working tree (the branch's fix) and
+   asserts the fix works.
+2. `git stash`-es the fix from the two patched files and re-runs to
+   demonstrate the pre-fix bugs reproduce.
+3. Restores the fix (also on Ctrl-C / errors via an `EXIT` trap).
+
+Expected output ends with `All N/N assertions passed.`
+
+## Requirements
+
+- `git`, `bash`
+- [`pixi`](https://pixi.sh) — everything else (`nextflow`, `samtools`,
+  `htslib`, `bcftools`) is fetched on demand via `pixi exec`.
+
+The harnesses run in Nextflow stub mode against the actual project
+modules and subworkflow — no external test datasets, no real PharmCAT
+container, ~30 seconds end-to-end.
+
+## What each harness exercises
+
+| MWE | What it forces |
+|-----|----------------|
+| `test_26_stage.nf` | Inspects the staged inputs in the `PHARMCAT_VCFPREPROCESSOR` workdir. Asserts 0 symlinks under the fix. |
+| `test_27_drift.nf` | Two samples, VCF meta has extra `data_type` field, BED meta has only `id`, BED emission order *reversed*. Asserts each sample's BCFTOOLS_VIEW task receives its own BED under the fix. |
+
+The dummy input files (`tests/mwe/inputs/`) are empty stubs created on
+the fly — Nextflow's stub-mode tasks don't read their contents.

--- a/tests/mwe/mwe.config
+++ b/tests/mwe/mwe.config
@@ -1,0 +1,13 @@
+// Configuration for the MWE harnesses (test_26_stage.nf, test_27_drift.nf).
+//
+// We inherit `conf/modules/pharmcat_vcf_processing.config` so the
+// `stageInMode = 'copy'` directive that carries the #26 fix actually
+// applies inside the MWE runs. That config references a couple of
+// pipeline-level params, so satisfy them here before including it.
+
+params {
+    publish_dir_mode = 'copy'
+    outdir           = 'out'
+    variant_caller   = 'deepvariant'
+}
+includeConfig '../../conf/modules/pharmcat_vcf_processing.config'

--- a/tests/mwe/run_demo.sh
+++ b/tests/mwe/run_demo.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# End-to-end demonstration of issues #26 and #27 and the fix on this branch.
+#
+# Runs the two MWE harnesses twice:
+#   1. POST-FIX: current working tree (the branch's fix). Asserts the fix
+#      works — PHARMCAT_VCFPREPROCESSOR workdir has no symlinks; per-sample
+#      BCFTOOLS_VIEW gets the right target-pass BED.
+#   2. PRE-FIX:  same MWEs against `git stash`-reverted versions of the
+#      two changed files. Asserts the bugs reproduce — staged inputs are
+#      symlinks back to source (=> htslib writes propagate to shared
+#      source .fai); BCFTOOLS_VIEW silently mispairs samples and BEDs.
+#
+# The stash is popped on exit (including on Ctrl-C / errors) so this script
+# never leaves the working tree in a half-state.
+#
+# Requirements: bash, git, pixi (https://pixi.sh).
+# All other tooling — nextflow, samtools, htslib, bcftools — is provisioned
+# on the fly by `pixi exec`.
+
+set -euo pipefail
+
+cd "$(dirname "$(realpath "${BASH_SOURCE[0]}")")"
+INPUTS_DIR="$PWD/inputs"
+PATCH_FILES=(
+    "conf/modules/pharmcat_vcf_processing.config"
+    "subworkflows/local/pharmcat_vcf_processing.nf"
+)
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+WORK_BASE="$PWD/.mwe-work"
+stashed=0
+ok=0; fail=0
+
+c_red='\033[31m'; c_grn='\033[32m'; c_yel='\033[33m'; c_blu='\033[34m'; c_off='\033[0m'
+
+restore_stash() {
+    if [[ "${stashed}" == "1" ]]; then
+        echo
+        echo -e "${c_blu}Restoring the fix from stash...${c_off}"
+        (cd "${REPO_ROOT}" && git stash pop --quiet) \
+            || echo -e "${c_red}WARN: stash pop failed; run \`git stash list\` and recover manually${c_off}"
+    fi
+}
+trap restore_stash EXIT
+
+ensure_inputs() {
+    mkdir -p "${INPUTS_DIR}"
+    for f in sampleA.vcf.gz sampleA.vcf.gz.tbi sampleB.vcf.gz sampleB.vcf.gz.tbi \
+             A_target.pass.bed B_target.pass.bed \
+             reference.fna.bgz reference.fna.bgz.fai \
+             positions.vcf.gz positions.vcf.gz.tbi \
+             uni.vcf.gz uni.vcf.gz.tbi; do
+        : > "${INPUTS_DIR}/${f}"
+    done
+}
+
+run_nf() {
+    local script="$1" wd="$2"
+    rm -rf "${wd}" "${wd}.nextflow"
+    pixi exec --spec 'nextflow=25.10' --spec 'htslib' --spec 'bcftools' -- \
+        nextflow run "${script}" -c mwe.config -stub \
+            -work-dir "${wd}" --outdir "${wd}/out" 2>&1 \
+        | tail -n 5
+}
+
+find_vcfpreprocessor_workdir() {
+    local wd="$1"
+    find "${wd}" -mindepth 2 -maxdepth 2 -type d 2>/dev/null | while read -r d; do
+        if grep -lq 'pharmcat_vcf_preprocessor\|missing_pgx_var' "$d/.command.sh" 2>/dev/null; then
+            echo "$d"; break
+        fi
+    done
+}
+
+list_bcftools_view_pairings() {
+    # echoes lines: "sample bed"
+    local wd="$1"
+    find "${wd}" -mindepth 2 -maxdepth 2 -type d 2>/dev/null | while read -r d; do
+        if grep -q 'gzip > sample' "$d/.command.sh" 2>/dev/null; then
+            local sample bed
+            sample=$(grep -oE 'sample[AB]' "$d/.command.sh" | head -1)
+            bed=$(ls "$d" | grep '\.bed$' | head -1)
+            echo "${sample} ${bed}"
+        fi
+    done
+}
+
+assert() {
+    local desc="$1" want="$2" got="$3"
+    if [[ "${want}" == "${got}" ]]; then
+        echo -e "  ${c_grn}PASS${c_off}  ${desc}: got '${got}'"
+        ok=$((ok+1))
+    else
+        echo -e "  ${c_red}FAIL${c_off}  ${desc}: want '${want}', got '${got}'"
+        fail=$((fail+1))
+    fi
+}
+
+run_phase() {
+    local label="$1" expect_symlinks="$2" expect_pair_a="$3" expect_pair_b="$4"
+
+    echo
+    echo -e "${c_blu}=== ${label} ===${c_off}"
+
+    echo "--- #26 (test_26_stage.nf) ---"
+    run_nf test_26_stage.nf "${WORK_BASE}/26"
+    local vcf_d
+    vcf_d=$(find_vcfpreprocessor_workdir "${WORK_BASE}/26")
+    if [[ -z "${vcf_d}" ]]; then
+        echo -e "  ${c_red}FAIL${c_off}  could not locate PHARMCAT_VCFPREPROCESSOR workdir"
+        fail=$((fail+1)); return
+    fi
+    local symlinks
+    symlinks=$(find "${vcf_d}" -maxdepth 1 -type l | wc -l)
+    if [[ "${expect_symlinks}" == "zero" ]]; then
+        assert "#26 input staging is by copy (0 symlinks)" "0" "${symlinks}"
+    else
+        if [[ "${symlinks}" -gt 0 ]]; then
+            echo -e "  ${c_grn}PASS${c_off}  #26 pre-fix bug reproduces: ${symlinks} symlinks back to source"
+            ok=$((ok+1))
+            echo "        e.g. $(find "${vcf_d}" -maxdepth 1 -type l -printf '%f -> %l\n' | head -1)"
+        else
+            echo -e "  ${c_red}FAIL${c_off}  expected symlinks but found 0"
+            fail=$((fail+1))
+        fi
+    fi
+
+    echo "--- #27 (test_27_drift.nf) ---"
+    run_nf test_27_drift.nf "${WORK_BASE}/27"
+    local pair_a pair_b
+    pair_a=$(list_bcftools_view_pairings "${WORK_BASE}/27" | awk '$1=="sampleA"{print $2}')
+    pair_b=$(list_bcftools_view_pairings "${WORK_BASE}/27" | awk '$1=="sampleB"{print $2}')
+    assert "#27 sampleA's BCFTOOLS_VIEW gets bed" "${expect_pair_a}" "${pair_a}"
+    assert "#27 sampleB's BCFTOOLS_VIEW gets bed" "${expect_pair_b}" "${pair_b}"
+}
+
+# --------------------------------------------------------------------------
+# Sanity checks
+# --------------------------------------------------------------------------
+if ! command -v pixi >/dev/null 2>&1; then
+    echo "ERROR: pixi not found. Install from https://pixi.sh" >&2
+    exit 1
+fi
+if ! git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+    echo "ERROR: not inside a git working tree" >&2
+    exit 1
+fi
+
+ensure_inputs
+rm -rf "${WORK_BASE}"
+
+# --------------------------------------------------------------------------
+# Phase 1 — POST-FIX (current working tree carries the fix)
+# --------------------------------------------------------------------------
+run_phase "PHASE 1 — POST-FIX (this branch's working tree)" \
+    "zero"             \
+    "A_target.pass.bed" \
+    "B_target.pass.bed"
+
+# --------------------------------------------------------------------------
+# Phase 2 — PRE-FIX (stash the fix in the two patched files)
+# --------------------------------------------------------------------------
+echo
+echo -e "${c_yel}Stashing the fix in:${c_off}"
+for f in "${PATCH_FILES[@]}"; do echo "  ${f}"; done
+
+stash_paths=()
+for f in "${PATCH_FILES[@]}"; do stash_paths+=( "${REPO_ROOT}/${f}" ); done
+
+if (cd "${REPO_ROOT}" && git stash push --quiet -m "mwe-demo: temporarily revert fix" -- "${PATCH_FILES[@]}"); then
+    stashed=1
+else
+    echo "WARN: stash push reported nothing to stash. Either the working tree was clean," >&2
+    echo "      or the fix was already at HEAD. Running pre-fix phase anyway." >&2
+fi
+
+run_phase "PHASE 2 — PRE-FIX (working tree reverted)" \
+    "many"             \
+    "B_target.pass.bed" \
+    "A_target.pass.bed"
+
+# --------------------------------------------------------------------------
+# Summary
+# --------------------------------------------------------------------------
+echo
+total=$((ok + fail))
+if [[ "${fail}" == "0" ]]; then
+    echo -e "${c_grn}All ${ok}/${total} assertions passed:${c_off}"
+    echo "  • POST-FIX: #26 staged copies (no symlinks); #27 correct per-sample BED pairing."
+    echo "  • PRE-FIX:  #26 staged symlinks back to source; #27 silently mispairs samples."
+    exit 0
+else
+    echo -e "${c_red}${fail}/${total} assertion(s) failed.${c_off}"
+    exit 1
+fi

--- a/tests/mwe/test_26_stage.nf
+++ b/tests/mwe/test_26_stage.nf
@@ -1,0 +1,39 @@
+// MWE for issue #26 — confirm `stageInMode = 'copy'` is in effect for
+// PHARMCAT_VCFPREPROCESSOR, so htslib's touch/rewrite of
+// `reference.fna.bgz.fai` cannot reach the shared source file via a symlink.
+//
+// Invokes the subworkflow (not the module directly) so the project's
+// `withName: '.*PHARMCAT_VCF_PROCESSING:PHARMCAT_VCFPREPROCESSOR'`
+// directive — which carries the fix — actually applies.
+//
+// The runner script (tests/mwe/run_demo.sh) asserts:
+//   POST-FIX: PHARMCAT_VCFPREPROCESSOR workdir contains 0 input symlinks,
+//             every staged file is a real per-task copy.
+//   PRE-FIX:  every staged input is a symlink back to projectDir/inputs/,
+//             so any htslib write through `reference.fna.bgz.fai` modifies
+//             the shared source — the race condition the issue describes.
+
+include { PHARMCAT_VCF_PROCESSING } from '../../subworkflows/local/pharmcat_vcf_processing'
+
+workflow {
+    ch_vcf = Channel.of([
+        [id:'sampleA'],
+        file("${projectDir}/inputs/sampleA.vcf.gz"),
+        file("${projectDir}/inputs/sampleA.vcf.gz.tbi")
+    ])
+    ch_fasta = Channel.value([[id:'ref'], file("${projectDir}/inputs/reference.fna.bgz")])
+    ch_idx   = Channel.value([[id:'ref'], file("${projectDir}/inputs/reference.fna.bgz.fai")])
+    ch_pos   = Channel.value([
+        [id:'pos'],
+        file("${projectDir}/inputs/positions.vcf.gz"),
+        file("${projectDir}/inputs/positions.vcf.gz.tbi")
+    ])
+    ch_uni   = Channel.value([
+        [id:'uni'],
+        file("${projectDir}/inputs/uni.vcf.gz"),
+        file("${projectDir}/inputs/uni.vcf.gz.tbi")
+    ])
+    ch_bed   = Channel.of([[id:'sampleA'], file("${projectDir}/inputs/A_target.pass.bed")])
+
+    PHARMCAT_VCF_PROCESSING(ch_vcf, ch_fasta, ch_idx, ch_pos, ch_uni, ch_bed)
+}

--- a/tests/mwe/test_27_drift.nf
+++ b/tests/mwe/test_27_drift.nf
@@ -1,0 +1,54 @@
+// MWE for issue #27 — confirm PHARMCAT_VCF_PROCESSING joins channels by
+// `meta.id`, even when the two channels carry meta dicts that share `id`
+// but differ in other fields.
+//
+// At runtime the VCF channel (post PHARMCAT_VCFPREPROCESSOR) and the BED
+// channel (from QC_BAM) come from different upstream subworkflows that
+// mutate meta differently. A `.join` on the *full* meta map therefore
+// fails to match; with `.failOnMismatch:true` it errors, with `false` it
+// silently drops or mispairs samples.
+//
+// This MWE forces the condition deterministically:
+//   - VCF channel meta carries an extra `data_type` field
+//   - BED channel meta has only `id`
+//   - BED emission order is REVERSED — would fall back to positional
+//     pairing under the pre-fix `.map { meta, bed -> [bed] }` pattern
+//
+// The runner script (tests/mwe/run_demo.sh) asserts:
+//   POST-FIX: sampleA's BCFTOOLS_VIEW gets A_target.pass.bed (and B gets B's)
+//   PRE-FIX:  silent mispair — sampleA gets B_target.pass.bed, vice versa.
+
+include { PHARMCAT_VCF_PROCESSING } from '../../subworkflows/local/pharmcat_vcf_processing'
+
+workflow {
+    ch_vcf = Channel.of(
+        [[id:'sampleA', data_type:'fastq_gz'],
+         file("${projectDir}/inputs/sampleA.vcf.gz"),
+         file("${projectDir}/inputs/sampleA.vcf.gz.tbi")],
+        [[id:'sampleB', data_type:'fastq_gz'],
+         file("${projectDir}/inputs/sampleB.vcf.gz"),
+         file("${projectDir}/inputs/sampleB.vcf.gz.tbi")]
+    )
+
+    // BED channel: meta has only `id` (no data_type — drift!), and emission
+    // order is B then A to expose positional pairing of the pre-fix code.
+    ch_bed = Channel.of(
+        [[id:'sampleB'], file("${projectDir}/inputs/B_target.pass.bed")],
+        [[id:'sampleA'], file("${projectDir}/inputs/A_target.pass.bed")]
+    )
+
+    ch_fasta = Channel.value([[id:'ref'], file("${projectDir}/inputs/reference.fna.bgz")])
+    ch_idx   = Channel.value([[id:'ref'], file("${projectDir}/inputs/reference.fna.bgz.fai")])
+    ch_pos   = Channel.value([
+        [id:'pos'],
+        file("${projectDir}/inputs/positions.vcf.gz"),
+        file("${projectDir}/inputs/positions.vcf.gz.tbi")
+    ])
+    ch_uni   = Channel.value([
+        [id:'uni'],
+        file("${projectDir}/inputs/uni.vcf.gz"),
+        file("${projectDir}/inputs/uni.vcf.gz.tbi")
+    ])
+
+    PHARMCAT_VCF_PROCESSING(ch_vcf, ch_fasta, ch_idx, ch_pos, ch_uni, ch_bed)
+}


### PR DESCRIPTION
Here are fixes created by claude code for issues #26, #27 and the bed mispair issue. They have been verified, minimal working examples are included. I also did a run using four real 1k genomes datasets, all seem to work properly. (Hopefully it does when you try also. )

Thought about breaking up into multiple PRs since Cat 2 is orthogonal but ultimately decided to include everything in one PR.

**Category 1 — The actual #26 / #27 fixes**
Commit 87d2079 — "fix: resolve PharmCAT pairing and staging issues in VCF processing"

File	Change
conf/modules/pharmcat_vcf_processing.config	+5
subworkflows/local/pharmcat_vcf_processing.nf	+24/-9
.gitignore	+1

**Category 2 — Pre-existing pipeline bugs we hit while validating**
These weren't in our scope but blocked the end-to-end run.

Commit 367bb0d — "fix: improve SAMTOOLS_MERGE handling for empty sample cases"

File	Change
subworkflows/local/align_bwa_bwamem2_bwameme/main.nf	~8 lines
Commit be699a7 — "fix: enhance SAMTOOLS_STATS input handling for genome fasta and fai"

File	Change
subworkflows/local/align_bwa_bwamem2_bwameme/main.nf	~5 lines
Also included in commit 87d2079 (could/should be split out)

File	Change
subworkflows/local/align_bwa_bwamem2_bwameme/main.nf	3 sites
subworkflows/local/align_sentieon/main.nf	1 site

**Category 3 — Validation infrastructure (new files under tests/)**
All under tests/ — adds reviewer-runnable verification, no pipeline code touched.

File	LOC	Purpose
tests/README.md	44	Index for tests/.
tests/download_validation_data.sh	179	Pulls PGx-region BAM slices of 4 GeT-RM samples from 1KG 30X, converts to paired FASTQs, builds a pipeline-ready samplesheet. Used to prep test_data/fastqs/ and test_data/samplesheet.csv.
tests/mwe/README.md	76	Explains #26 + #27 and how to run the demo.
tests/mwe/run_demo.sh	195	One-shot before/after demo. Runs both MWEs at HEAD (post-fix), then git stash-es the fix and re-runs (pre-fix), then restores. Asserts 6 expected outcomes.
tests/mwe/test_26_stage.nf	39	MWE harness exercising the stageInMode fix.
tests/mwe/test_27_drift.nf	54	MWE harness exercising the join-by-id fix with drifted meta + reversed BED order.
tests/mwe/mwe.config	13	Inherits the project's PHARMCAT config so MWEs pick up the directive under test.
tests/mwe/.gitignore	2	Hides MWE-run scratch dirs.