### PR TITLE
Bugfixes in subworkflow align_bwa_bwamem2_bwameme

### DIFF
--- a/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
+++ b/subworkflows/local/align_bwa_bwamem2_bwameme/main.nf
@@ -58,8 +58,8 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
         SAMTOOLS_INDEX_ALIGN ( ch_align )
 
         // Get stats for each demultiplexed read pair.
-        bam_sorted_indexed = ch_align.join(SAMTOOLS_INDEX_ALIGN.out.bai, failOnMismatch:true, failOnDuplicate:true)
-        SAMTOOLS_STATS ( bam_sorted_indexed, [[],[]] )
+        bam_sorted_indexed = ch_align.join(SAMTOOLS_INDEX_ALIGN.out.index, failOnMismatch:true, failOnDuplicate:true)
+        SAMTOOLS_STATS ( bam_sorted_indexed, ch_genome_fasta.combine(ch_genome_fai.map { _meta, fai -> fai }) )
 
         // Merge multiple lane samples and index
         ch_align
@@ -76,13 +76,13 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
             .set{ bams }
 
         // If there are no samples to merge, skip the process
-        SAMTOOLS_MERGE ( bams.multiple, ch_genome_fasta, ch_genome_fai, [])
+        SAMTOOLS_MERGE ( bams.multiple, ch_genome_fasta.combine(ch_genome_fai.map { _meta, fai -> fai }))
         prepared_bam = bams.single.mix(SAMTOOLS_MERGE.out.bam)
 
         // GET ALIGNMENT FROM SELECTED CONTIGS
         if (params.extract_alignments) {
             SAMTOOLS_INDEX_EXTRACT ( prepared_bam )
-            extract_bam_sorted_indexed = prepared_bam.join(SAMTOOLS_INDEX_EXTRACT.out.bai, failOnMismatch:true, failOnDuplicate:true)
+            extract_bam_sorted_indexed = prepared_bam.join(SAMTOOLS_INDEX_EXTRACT.out.index, failOnMismatch:true, failOnDuplicate:true)
             EXTRACT_ALIGNMENTS( extract_bam_sorted_indexed, ch_genome_fasta, [])
             prepared_bam = EXTRACT_ALIGNMENTS.out.bam
         }
@@ -94,5 +94,5 @@ workflow ALIGN_BWA_BWAMEM2_BWAMEME {
         stats       = SAMTOOLS_STATS.out.stats       // channel: [ val(meta), path(stats) ]
         metrics     = MARKDUPLICATES.out.metrics     // channel: [ val(meta), path(metrics) ]
         marked_bam  = MARKDUPLICATES.out.bam         // channel: [ val(meta), path(bam) ]
-        marked_bai  = SAMTOOLS_INDEX_MARKDUP.out.bai // channel: [ val(meta), path(bai) ]
+        marked_bai  = SAMTOOLS_INDEX_MARKDUP.out.index // channel: [ val(meta), path(bai) ]
 }


### PR DESCRIPTION
Fixes issues with calls to samtools modules from the subworkflow align_bwa_bwamem2_bwameme (due to updates in the nf-core modules):
 https://github.com/SMD-Bioinformatics-Lund/PrecisionPGx/issues/34#issue-5279379284

Fixes as https://github.com/parlar proposed in https://github.com/SMD-Bioinformatics-Lund/PrecisionPGx/commit/be699a7c65248076a34434b6ae571e78090dc623 and https://github.com/SMD-Bioinformatics-Lund/PrecisionPGx/commit/87d2079835b65885d3fdfb66b32c8fbac5bfcf94

(or similar to - removed the unnecessary mapping step as commented here: https://github.com/SMD-Bioinformatics-Lund/PrecisionPGx/pull/31#discussion_r3587056276)

Fixes are tested and working.