### PR TITLE
updated pharmcat_vcf_processing.config to avoid .fai-racing

### DIFF
--- a/conf/modules/pharmcat_vcf_processing.config
+++ b/conf/modules/pharmcat_vcf_processing.config
@@ -28,6 +28,11 @@ process {
     withName: '.*PHARMCAT_VCF_PROCESSING:PHARMCAT_VCFPREPROCESSOR' {
         ext.args = {" --missing-to-ref "} //Assume all non-called sites are reference
         ext.prefix = { "${meta.id}.${params.variant_caller}.pharmcat" }
+        // Copy (don't symlink) inputs into the workdir so that when htslib
+        // touches/rewrites reference.fna.bgz.fai it touches the per-task
+        // copy, not the shared source file. Without this, parallel tasks
+        // race on the source-side .fai (issue #26).
+        stageInMode = 'copy'
     }
 
     withName: '.*PHARMCAT_VCF_PROCESSING:BCFTOOLS_VIEW' {


### PR DESCRIPTION
Addresses the issue in https://github.com/SMD-Bioinformatics-Lund/PrecisionPGx/issues/26
Changes in conf/modules/pharmcat_vcf_processing.config as proposed by https://github.com/parlar, adding stageInMode='copy'  to avoid racing for the source .fai.